### PR TITLE
Added optional config keys to the Pushover Backend

### DIFF
--- a/ntfy/backends/pushover.py
+++ b/ntfy/backends/pushover.py
@@ -1,10 +1,11 @@
 import requests
+import logging
 
 
 def notify(title, message, user_key,
            api_token='aUnsraBiEZVsmrG89AZp47K3S2dX2a', device=None,
-           sound=None, priority=0, expire=30,
-           retry=30, callback=None, **kwargs):
+           sound=None, priority=0, expire=None,
+           retry=None, callback=None, **kwargs):
     """
     Required config keys:
         * 'user_key'
@@ -28,21 +29,47 @@ def notify(title, message, user_key,
     if sound:
         data['sound'] = sound
 
-    if priority != 0 and priority <= 2 and priority >= -2:
-        data['priority'] = priority
+    if priority <= 2 and priority >= -2:
+        if priority != 0:
+            data['priority'] = priority
 
         # Expire, Retry, and Callback only apply to an Emergency Priority
         if priority == 2:
             # Retry can not be less than 30 per the API
-            if retry < 30:
+            if not retry or retry < 30:
+                logging.getLogger(__name__).error(
+                    'retry is less than 30 or is not set, '
+                    'setting retry to 30 to comply with '
+                    'pushover API requirements')
                 data['retry'] = 30
             else:
                 data['retry'] = retry
 
-            data['expire'] = expire
+            # Expire can not be more than 86400 (24 hours)
+            if not expire or expire > 86400:
+                logging.getLogger(__name__).error(
+                    'expire is greater than 86400 seconds or is not set,'
+                    'setting expire to 86400 to comply with'
+                    'pushover API requirements')
+                data['expire'] = 86400
+            elif expire <= 86400:
+                data['expire'] = expire
 
             if callback:
                 data['callback'] = callback
+        else:
+            if retry:
+                logging.getLogger(__name__).warning(
+                    'Non-emergency, ignoring retry set in config')
+            if expire:
+                logging.getLogger(__name__).warning(
+                    'Non-emergency, ignoring expire set in config')
+            if callback:
+                logging.getLogger(__name__).warning(
+                    'Non-emergency, ignoring callback set in config')
+
+    else:
+        raise ValueError('priority must be an integer from -2 to 2')
 
     resp = requests.post('https://api.pushover.net/1/messages.json',
                          data=data)

--- a/ntfy/backends/pushover.py
+++ b/ntfy/backends/pushover.py
@@ -2,12 +2,20 @@ import requests
 
 
 def notify(title, message, user_key,
-           api_token='aUnsraBiEZVsmrG89AZp47K3S2dX2a', device=None, **kwargs):
+           api_token='aUnsraBiEZVsmrG89AZp47K3S2dX2a', device=None,
+           sound=None, priority=0, expire=30,
+           retry=30, callback=None, **kwargs):
     """
     Required config keys:
         * 'user_key'
-    """
 
+    Optional config keys:
+        * 'sound'
+        * 'priority'
+        * 'expire'
+        * 'retry'
+        * 'callback'
+    """
     data = {
         'message': message,
         'token': api_token,
@@ -16,6 +24,25 @@ def notify(title, message, user_key,
     }
     if device:
         data['device'] = device
+
+    if sound:
+        data['sound'] = sound
+
+    if priority != 0 and priority <= 2 and priority >= -2:
+        data['priority'] = priority
+
+        # Expire, Retry, and Callback only apply to an Emergency Priority
+        if priority == 2:
+            # Retry can not be less than 30 per the API
+            if retry < 30:
+                data['retry'] = 30
+            else:
+                data['retry'] = retry
+
+            data['expire'] = expire
+
+            if callback:
+                data['callback'] = callback
 
     resp = requests.post('https://api.pushover.net/1/messages.json',
                          data=data)


### PR DESCRIPTION
Example config:
```yaml
backends:
    - pushover
pushover:
    user_key: redacted                     
    sound: alien
    priority: 2
    expire: 60
    retry: 3600
    callback: https://callbackurl
```