### PR TITLE
no to sudo

### DIFF
--- a/ntfy/shell_integration/auto-ntfy-done.sh
+++ b/ntfy/shell_integration/auto-ntfy-done.sh
@@ -4,7 +4,7 @@
 # Default timeout is 10 seconds.
 AUTO_NTFY_DONE_TIMEOUT=${AUTO_NTFY_DONE_TIMEOUT:-10}
 # Default to ignoring some well known interactive programs
-AUTO_NTFY_DONE_IGNORE=${AUTO_NTFY_DONE_IGNORE:-emacs info less mail man meld most mutt nano screen ssh tail tmux vi vim}
+AUTO_NTFY_DONE_IGNORE=${AUTO_NTFY_DONE_IGNORE:-emacs info less mail man meld most mutt nano screen ssh tail tmux top vi vim}
 # Bash option example
 #AUTO_NTFY_DONE_OPTS='-b default'
 # Zsh option example

--- a/ntfy/shell_integration/auto-ntfy-done.sh
+++ b/ntfy/shell_integration/auto-ntfy-done.sh
@@ -4,7 +4,7 @@
 # Default timeout is 10 seconds.
 AUTO_NTFY_DONE_TIMEOUT=${AUTO_NTFY_DONE_TIMEOUT:-10}
 # Default to ignoring some well known interactive programs
-AUTO_NTFY_DONE_IGNORE=${AUTO_NTFY_DONE_IGNORE:-emacs info less mail man meld most mutt nano screen ssh sudo tail tmux vi vim}
+AUTO_NTFY_DONE_IGNORE=${AUTO_NTFY_DONE_IGNORE:-emacs info less mail man meld most mutt nano screen ssh tail tmux vi vim}
 # Bash option example
 #AUTO_NTFY_DONE_OPTS='-b default'
 # Zsh option example


### PR DESCRIPTION
I think it may be best to take sudo out, unless you know how to fix this:
if I `sudo vim  /etc/file.conf` that will cause ntfy to send the notification--not really desired. however, If there's a very long sudo process running, like `sudo make buildworld` on freebsd, when it's completed, ntfy won't send the notification because it's marked to ignore sudo. 
So is there an elegant way to ignore `sudo vim, tmux, emacs`, etc but watch long running processes that also run as sudo?