### PR TITLE
Allow overriding backend in it's own config, fixes #30

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -99,6 +99,18 @@ it's own configuration, stored in a key of it's own name. For example:
          mtype: "chat"
          recipient: "me@jit.si"
 
+If you want mulitple configs for the same backend type, you can specify any
+name and then specify the backend with a backend key. For example:
+
+::
+
+    ---
+    pushover:
+        user_key: hunter2
+    cellphone:
+        backend: pushover
+        user_key: hunter2
+
 See the backends bellow for available backends and options.
 
 `Pushover <https://pushover.net>`_ - ``pushover``

--- a/ntfy/__init__.py
+++ b/ntfy/__init__.py
@@ -24,6 +24,10 @@ def notify(message, title, config=None, **kwargs):
     ret = 0
 
     for backend in config.get('backends', ['default']):
+        backend_config = config.get(backend, {})
+        backend_config.update(kwargs)
+        if 'backend' in backend_config:
+            backend = backend_config['backend']
         try:
             module = import_module('ntfy.backends.{}'.format(backend))
         except ImportError:
@@ -32,9 +36,6 @@ def notify(message, title, config=None, **kwargs):
                 'failed to load backend {}'.format(backend),
                 exc_info=True)
             continue
-
-        backend_config = config.get(backend, {})
-        backend_config.update(kwargs)
 
         try:
             module.notify(message=message, title=title, **backend_config)

--- a/tests/ntfy_test/__init__.py
+++ b/tests/ntfy_test/__init__.py
@@ -1,1 +1,20 @@
+from unittest import TestCase
+
+from mock import patch
+
+from ntfy import notify
+
 from . import cli
+
+
+class OverrideBackendTestCase(TestCase):
+    @patch('requests.post')
+    def test_runcmd(self, mock_post):
+        ret = notify('message', 'title', {
+            'backends': ['foobar'],
+            'foobar': {
+                'backend': 'pushover',
+                'user_key': 't0k3n',
+            }
+        })
+        self.assertEqual(ret, 0)


### PR DESCRIPTION
To try this out: 
```
sudo pip3 install -U git+https://github.com/dschep/ntfy@feature/mutli-backendtype-configs#egg=ntfy
```
cc @danryder 