### PR TITLE
Simplepush backend

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -97,12 +97,15 @@ its own configuration, stored in a key of its own name. For example:
     ---
     backends:
         - pushover
+        - simplepush
         - linux
         - xmpp
     pushover:
         user_key: hunter2
     pushbullet:
         access_key: hunter2
+    simplepush:
+        key: hunter2
     xmpp:
          jid: "user@gmail.com"
          password: "xxxx"
@@ -148,6 +151,11 @@ Required parameter:
 Optional parameters:
     * ``device_iden`` - a device identifier, if omited, notification is sent to all devices
     * ``email`` - send notification to pushbullte user with the specified email or send an email if they aren't a pushullet user
+
+`Simplepush <https://simplepush.io>`_ - ``simplepush``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Required parameter:
+    * ``key`` - Your Simplepush key, created by installing the Android App (no registration required) at https://simplepush.io
 
 XMPP - ``xmpp``
 ~~~~~~~~~~~~~~~
@@ -241,6 +249,7 @@ Contributors
 - `oz123 <https://github.com/oz123>`_ - Linux desktop notification improvements
 - `schwert <https://github.com/schwert>`_ - PushJet support
 - `rahiel <https://github.com/rahiel>`_ - Telegram support
+- `tymm <https://github.com/tymm>`_ - Simplepush support
 - `jungle-boogie <https://github.com/jungle-boogie>`_ - Documentation updates
 - `tjbenator <https://github.com/tjbenator>`_ - Advanced Pushover options
 - `mobiusklein <https://github.com/mobiusklein>`_ - Win32 Bugfix

--- a/docs/ntfy.backends.rst
+++ b/docs/ntfy.backends.rst
@@ -44,6 +44,14 @@ ntfy.backends.pushover module
     :undoc-members:
     :show-inheritance:
 
+ntfy.backends.simplepush module
+-----------------------------
+
+.. automodule:: ntfy.backends.simplepush
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 ntfy.backends.win32 module
 --------------------------
 

--- a/ntfy/__init__.py
+++ b/ntfy/__init__.py
@@ -9,7 +9,7 @@ __version__ = '2.1.1'
 notifiers = {'default': None, 'darwin': None, 'linux': None,
              'darwin': None, 'pushbullet': None, 'pushover': None,
              'pushjet': None, 'telegram': None, 'win32': None,
-             'xmpp': None}
+             'xmpp': None, 'simplepush': None}
 
 
 for k, v in notifiers.items():

--- a/ntfy/backends/simplepush.py
+++ b/ntfy/backends/simplepush.py
@@ -1,0 +1,28 @@
+import requests
+
+from ..config import USER_AGENT
+
+def notify(title,
+           message,
+           key):
+    """
+    Required paramter:
+        * ``key`` - The Simplepush identification key, created by
+        installing the Android App (https://simplepush.io)
+    """
+
+    data = {
+        'title': title,
+        'msg': message,
+        'key': key
+    }
+
+    headers = {'User-Agent': USER_AGENT}
+
+    endpoint = "https://api.simplepush.io"
+
+    resp = requests.post(endpoint + '/send',
+                         data=data,
+                         headers=headers)
+
+    resp.raise_for_status()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -32,6 +32,16 @@ class TestIntegration(TestCase):
         ntfy_main(['send', 'foobar'])
 
     @patch(builtin_module + '.open', mock_open())
+    @patch('ntfy.config.yaml.load')
+    @patch('ntfy.backends.simplepush.requests.post')
+    def test_simplepush(self, mock_post, mock_yamlload):
+        mock_yamlload.return_value = {
+            'backends': ['simplepush'],
+            'simplepush': {'key': MagicMock()},
+        }
+        ntfy_main(['send', 'foobar'])
+
+    @patch(builtin_module + '.open', mock_open())
     @patch('ntfy.backends.default.platform', 'linux')
     @patch('ntfy.config.yaml.load')
     def test_default(self, mock_yamlload):

--- a/tests/test_simplepush.py
+++ b/tests/test_simplepush.py
@@ -1,0 +1,17 @@
+from unittest import TestCase
+from mock import patch
+
+from ntfy.backends.simplepush import notify
+from ntfy.config import USER_AGENT
+
+
+class TestSimplepush(TestCase):
+    @patch('requests.post')
+    def test_basic(self, mock_post):
+        notify('title', 'message', key='secret')
+        mock_post.assert_called_once_with(
+            'https://api.simplepush.io/send',
+            data={'title': 'title',
+                  'msg': 'message',
+                  'key': 'secret'},
+            headers={'User-Agent': USER_AGENT})


### PR DESCRIPTION
Not sure if everything is correct since I can't run it locally with simplepush as backend.

```
tymm@mybox ~$ ntfy send "test"                                                                                                                                            
Traceback (most recent call last):
  File "/usr/local/bin/ntfy", line 9, in <module>
    load_entry_point('ntfy==2.1.1', 'console_scripts', 'ntfy')()
  File "build/bdist.linux-x86_64/egg/ntfy/cli.py", line 304, in main
  File "build/bdist.linux-x86_64/egg/ntfy/__init__.py", line 59, in notify
TypeError: object of type 'NoneType' has no len()
```