### PR TITLE
default title cwd bug fix

### DIFF
--- a/ntfy/__init__.py
+++ b/ntfy/__init__.py
@@ -14,8 +14,13 @@ notifiers = {'default': None, 'darwin': None, 'linux': None,
              'pushjet': None, 'telegram': None, 'win32': None,
              'xmpp': None, 'simplepush': None, 'notifico': None}
 
-default_title = '{}@{}:{}'.format(getuser(), gethostname(), getcwd().replace(
-    path.expanduser('~'), '~'))
+_user_home = path.expanduser('~')
+_cwd = getcwd()
+if _cwd.startswith(_user_home):
+    default_title = '{}@{}:{}'.format(getuser(), gethostname(),
+                                      path.join('~', _cwd[len(_user_home):]))
+else:
+    default_title = '{}@{}:{}'.format(getuser(), gethostname(), _cwd)
 
 
 for k, v in notifiers.items():


### PR DESCRIPTION
If the current working directory contains a similar folder structure to that of user home then the default title is displaying wrong cwd.

example screenshot:
here the current working directory is `/tmp/home/eightnoteight/test`
but the default title is set to `/tmp~/test`
![screenshot from 2016-08-30 18-54-27](https://cloud.githubusercontent.com/assets/6435796/18100420/9467dbbe-6f08-11e6-850e-f1e90f7258af.png)
