### PR TITLE
Execute commands through shell

### DIFF
--- a/ntfy/cli.py
+++ b/ntfy/cli.py
@@ -42,7 +42,7 @@ def run_cmd(args):
             exit(1)
     else:
         start_time = time()
-        retcode = call(args.command)
+        retcode = call(args.command, shell=True)
         duration = time() - start_time
     if args.longer_than is not None and duration <= args.longer_than:
         return None, None


### PR DESCRIPTION
As of now, simple commands like `ntfy done dir` fail with
`FileNotFoundError: [WinError 2] The system cannot find the file specified`

This change fixes that.
