### PR TITLE
Use more bullet-proof quoting for user values

### DIFF
--- a/ntfy/cli.py
+++ b/ntfy/cli.py
@@ -7,6 +7,11 @@ from sys import exit, stderr
 from time import time
 
 try:
+    from shlex import quote as sh_quote
+except ImportError:
+    from pipes import quote as sh_quote
+
+try:
     from emoji import emojize
 except ImportError:
     emojize = None
@@ -86,8 +91,8 @@ def auto_done(args):
     if args.unfocused_only:
         print('export AUTO_NTFY_DONE_UNFOCUSED_ONLY=-b')
     if args.shell == 'bash':
-        print('source "{}"'.format(scripts['bash-preexec.sh']))
-    print('source "{}"'.format(scripts['auto-ntfy-done.sh']))
+        print('source {}'.format(sh_quote(scripts['bash-preexec.sh'])))
+    print('source {}'.format(sh_quote(scripts['auto-ntfy-done.sh'])))
     print("# To use ntfy's shell integration, run "
           "this and add it to your shell's rc file:")
     print('# eval "$(ntfy shell-integration)"')


### PR DESCRIPTION
@eightnoteight [rightly suggested](https://github.com/dschep/ntfy/pull/107#issuecomment-245922708) that `shlex.quote()` be use to quote the user values, rather than naive hard-quoted quotes. The risk of code injection is probably low, but it's just plain better practice.

`shlex.quote()` is available from Py 3.3 onward. `pipes.quote()` is available in 2.7. Based on the trove classifiers in setup.py, I think this should cover our bases.