### PR TITLE
Fix integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ python:
   - '3.5'
   - pypy
 install:
-  - pip install .
+  - pip install -U pip setuptools
+  - pip install . .[xmpp]
   - pip install coveralls flake8 twine
 script: coverage run --source=ntfy setup.py test && bash zipapp.sh && flake8 ntfy
 after_success: coveralls

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ init:
 install:
   # FIXME: updating pip fails with PermissionError
   # - "%PYTHON%/Scripts/pip.exe install -U pip setuptools"
-  - "%PYTHON%/Scripts/pip.exe install -e ."
+  - "%PYTHON%/Scripts/pip.exe install -e . .[xmpp]"
 
 test_script:
   - "%PYTHON%/Scripts/pip.exe --version"

--- a/ntfy/cli.py
+++ b/ntfy/cli.py
@@ -132,7 +132,7 @@ parser.add_argument('-b',
 parser.add_argument('-o',
                     '--option',
                     nargs=2,
-                    default={},
+                    default=None,
                     action=BackendOptionAction,
                     metavar=('key', 'value'),
                     help='backend specific options')
@@ -284,6 +284,8 @@ def main(cli_args=None):
     if args.backend:
         config['backends'] = args.backend
 
+    if args.option is None:
+        args.option = {}
     for backend, backend_options in args.option.items():
         if backend is not None:
             config.setdefault(backend, {}).update(backend_options)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -51,8 +51,10 @@ class TestRunCmd(TestCase):
 class TestMain(TestCase):
     @patch('ntfy.backends.default.notify')
     def test_args(self, mock_notify):
-        ntfy_main(['-o', 'foo', 'bar', '-b', 'default', '-t', 'TITLE', 'send',
-                   'test'])
+        self.assertEquals(0, ntfy_main(['-o', 'foo', 'bar',
+                                        '-b', 'default',
+                                        '-t', 'TITLE',
+                                        'send', 'test']))
         mock_notify.assert_called_once_with(message='test',
                                             title='TITLE',
                                             foo='bar',

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -19,7 +19,7 @@ class TestIntegration(TestCase):
             'backends': ['pushover'],
             'pushover': {'user_key': MagicMock()},
         }
-        ntfy_main(['send', 'foobar'])
+        self.assertEqual(0, ntfy_main(['send', 'foobar']))
 
     @patch(builtin_module + '.open', mock_open())
     @patch('ntfy.config.yaml.load')
@@ -29,7 +29,7 @@ class TestIntegration(TestCase):
             'backends': ['pushbullet'],
             'pushbullet': {'access_token': MagicMock()},
         }
-        ntfy_main(['send', 'foobar'])
+        self.assertEqual(0, ntfy_main(['send', 'foobar']))
 
     @patch(builtin_module + '.open', mock_open())
     @patch('ntfy.config.yaml.load')
@@ -39,7 +39,7 @@ class TestIntegration(TestCase):
             'backends': ['simplepush'],
             'simplepush': {'key': MagicMock()},
         }
-        ntfy_main(['send', 'foobar'])
+        self.assertEqual(0, ntfy_main(['send', 'foobar']))
 
     @patch(builtin_module + '.open', mock_open())
     @patch('ntfy.backends.default.platform', 'linux')
@@ -49,7 +49,7 @@ class TestIntegration(TestCase):
         modules['dbus'] = MagicMock()
         try:
             mock_yamlload.return_value = {'backends': ['default'], }
-            ntfy_main(['send', 'foobar'])
+            self.assertEqual(0, ntfy_main(['send', 'foobar']))
         finally:
             if old_dbus is not None:
                 modules['dbus'] = old_dbus
@@ -61,7 +61,7 @@ class TestIntegration(TestCase):
         modules['dbus'] = MagicMock()
         try:
             mock_yamlload.return_value = {'backends': ['linux'], }
-            ntfy_main(['send', 'foobar'])
+            self.assertEqual(0, ntfy_main(['send', 'foobar']))
         finally:
             if old_dbus is not None:
                 modules['dbus'] = old_dbus
@@ -77,7 +77,7 @@ class TestIntegration(TestCase):
         modules['AppKit'] = MagicMock()
         try:
             mock_yamlload.return_value = {'backends': ['darwin'], }
-            ntfy_main(['send', 'foobar'])
+            self.assertEqual(0, ntfy_main(['send', 'foobar']))
         finally:
             if old_foundation is not None:
                 modules['Foundation'] = old_foundation
@@ -97,7 +97,7 @@ class TestIntegration(TestCase):
         modules['win32con'] = MagicMock()
         try:
             mock_yamlload.return_value = {'backends': ['win32'], }
-            ntfy_main(['send', 'foobar'])
+            self.assertEqual(0, ntfy_main(['send', 'foobar']))
         finally:
             if old_win32api is not None:
                 modules['win32api'] = old_win32api
@@ -114,7 +114,7 @@ class TestIntegration(TestCase):
                                       'xmpp': {'jid': 'foo@bar',
                                                'password': 'hunter2',
                                                'recipient': 'bar@foo'}}
-        ntfy_main(['send', 'foobar'])
+        self.assertEqual(0, ntfy_main(['send', 'foobar']))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
* Always check return value of ntfy_main (no longer using exceptions)
* Do not use a dict as the default of args.option

The latter accidentally shared state across tests, breaking all
integration tests. However, this was hidden because exceptions are now
caught and integration tests were not checking return values.