### PR TITLE
Fix osascript_tell in Python 3

### DIFF
--- a/ntfy/terminal.py
+++ b/ntfy/terminal.py
@@ -18,8 +18,8 @@ def linux_window_is_focused():
 def osascript_tell(app, script):
     p = Popen(['osascript'], stdin=PIPE, stdout=PIPE)
     stdout, stderr = p.communicate(
-        'tell application "{}"\n{}\nend tell'.format(app, script))
-    return stdout.rstrip('\n')
+        'tell application "{}"\n{}\nend tell'.format(app, script).encode('utf-8'))
+    return stdout.decode('utf-8').rstrip('\n')
 
 
 def darwin_iterm2_shell_is_focused():

--- a/ntfy/terminal.py
+++ b/ntfy/terminal.py
@@ -18,7 +18,8 @@ def linux_window_is_focused():
 def osascript_tell(app, script):
     p = Popen(['osascript'], stdin=PIPE, stdout=PIPE)
     stdout, stderr = p.communicate(
-        'tell application "{}"\n{}\nend tell'.format(app, script).encode('utf-8'))
+        ('tell application "{}"\n{}\nend tell'.format(app, script)
+         .encode('utf-8')))
     return stdout.decode('utf-8').rstrip('\n')
 
 


### PR DESCRIPTION
In Python 3, `subprocess.Popen.communicate()` requires (and returns) a bytes object, not a string. This change fixes `ntfy.terminal.osascript_tell()` to observe string/bytes discipline.

I have not checked for any other instances of `subprocess.Popen` usage. This change allows shell integration to work under Python 3.5.1 and OS X El Capitan (10.11.6).