### PR TITLE
Fix #77 - Stop throwing exceptions if $WINDOWID has not been set.

### DIFF
--- a/ntfy/terminal.py
+++ b/ntfy/terminal.py
@@ -1,6 +1,7 @@
 from os import environ, ttyname
 from subprocess import check_output, Popen, PIPE
 from sys import platform, stdout
+import shlex
 
 
 def get_tty():
@@ -10,9 +11,10 @@ def get_tty():
 
 
 def linux_window_is_focused():
-    window_id = int(check_output(['xprop', '-root', '\t$0',
-                                  '_NET_ACTIVE_WINDOW']).split()[1], 16)
-    return int(environ['WINDOWID']) == window_id
+    xprop_cmd = shlex.split('xprop -root _NET_ACTIVE_WINDOW')
+    xprop_window_id = int(check_output(xprop_cmd).split()[-1], 16)
+    env_window_id = int(environ.get('WINDOWID', '0'))
+    return env_window_id == xprop_window_id
 
 
 def osascript_tell(app, script):


### PR DESCRIPTION
``` python
Traceback (most recent call last):                                                                                                                                                                                 
  File "/usr/bin/ntfy", line 11, in <module>
    load_entry_point('ntfy==2.4.1', 'console_scripts', 'ntfy')()
  File "/usr/lib/python3.6/site-packages/ntfy/cli.py", line 341, in main
    message, retcode = args.func(args)
  File "/usr/lib/python3.6/site-packages/ntfy/cli.py", line 64, in run_cmd
    if args.unfocused_only and is_focused():
  File "/usr/lib/python3.6/site-packages/ntfy/terminal.py", line 61, in is_focused
    return linux_window_is_focused()
  File "/usr/lib/python3.6/site-packages/ntfy/terminal.py", line 15, in linux_window_is_focused
    return int(environ['WINDOWID']) == window_id
  File "/usr/lib/python3.6/os.py", line 669, in __getitem__
    raise KeyError(key) from None
KeyError: 'WINDOWID'
```
The `KeyError` comes from the usage of `environ["WINDOWID"]`. What should be used instead is the `get` method, e.g. `environ.get("WINDOWID")` which return `None` if the key is missing. Of course `None` is also a non-valid argument for `int()` but I think that defaulting to `0` is reasonable.