### PR TITLE
Support configuring the urgency level on linux backend

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -274,6 +274,9 @@ The following dependecies should be installed.
 
 You will need to install some font that supports emojis (in Debian `fonts-symbola` or Gentoo `media-fonts/symbola`).
 
+Optional parameters:
+    * ``urgency``
+
 Windows Desktop Notifications - ``win32``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Uses ``pywin32``.

--- a/ntfy/backends/linux.py
+++ b/ntfy/backends/linux.py
@@ -3,7 +3,7 @@ from os import environ, path
 from ..data import icon
 
 
-def notify(title, message, icon=icon.png, retcode=0):
+def notify(title, message, icon=icon.png, urgency=None, retcode=0):
     try:
         import dbus
     except ImportError:
@@ -27,7 +27,20 @@ def notify(title, message, icon=icon.png, retcode=0):
                               '/org/freedesktop/Notifications')
     dbus_iface = dbus.Interface(dbus_obj,
                                 dbus_interface='org.freedesktop.Notifications')
-    hints = {'urgency': dbus.Byte(2)} if retcode else {}
+
+    hints = {}
+
+    # Override the retcode if the urgency
+    if urgency == 'low':
+        hints = {'urgency': dbus.Byte(0)}
+    elif urgency == 'normal':
+        hints = {'urgency': dbus.Byte(1)}
+    elif urgency == 'critical':
+        hints = {'urgency': dbus.Byte(2)}
+    # Fallback to the return code to determine the urgency flag.
+    elif retcode:
+        hints = {'urgency': dbus.Byte(2)}
+
     message = message.replace('&', '&amp;')
     dbus_iface.Notify('ntfy', 0, path.abspath(icon), title, message, [], hints,
                       -1)


### PR DESCRIPTION
Currently the `notify-send` base backend for linux will set the `urgency` flag via dbus. This is a sensible default but usually I have couple background command that fails and having a sticky notification will block the remaining notifications until manually closed. I wanted a way to configure the `linux` backend and add the option to set a default `urgency` level.

Obviously this is still WIP, Feel free to suggest improvements and docs updates.