### PR TITLE
Support the transient behavior for the linux backend

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -276,7 +276,8 @@ The following dependecies should be installed.
 You will need to install some font that supports emojis (in Debian `fonts-symbola` or Gentoo `media-fonts/symbola`).
 
 Optional parameters:
-    * ``urgency``
+    * ``urgency`` - Specifies the urgency level (low, normal, critical).
+    * ``transient`` - Skip the history (exp: the Gnome message tray) (true, false).
 
 Windows Desktop Notifications - ``win32``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/ntfy/backends/linux.py
+++ b/ntfy/backends/linux.py
@@ -3,7 +3,7 @@ from os import environ, path
 from ..data import icon
 
 
-def notify(title, message, icon=icon.png, urgency=None, retcode=0):
+def notify(title, message, icon=icon.png, urgency=None, transient=None, retcode=0):
     try:
         import dbus
     except ImportError:
@@ -41,6 +41,12 @@ def notify(title, message, icon=icon.png, urgency=None, retcode=0):
     elif retcode:
         hints = {'urgency': dbus.Byte(2)}
 
+    if transient == "true":
+        hints.update({'transient': dbus.Byte(1)})
+    elif transient == "false":
+        hints.update({'transient': dbus.Byte(0)})
+    elif transient is not None:
+        logger.warn('Unexpected value for the "transient" option. Expected values ("true", "false").')
+
     message = message.replace('&', '&amp;')
-    dbus_iface.Notify('ntfy', 0,
-                      path.abspath(icon), title, message, [], hints, -1)
+    dbus_iface.Notify('ntfy', 0, path.abspath(icon), title, message, [], hints, -1)


### PR DESCRIPTION
Using ntfy with the Gnome desktop can very quickly fillup the panel's message tray. 

![ntfy_terminal](https://user-images.githubusercontent.com/1914306/30983016-74e02fa0-a489-11e7-9465-33fe06c601e7.png)

This PR Adds support for making the notification "skip the history". The notification message will show up as usual, but it does not persist in the notification history if available (in my case the message tray).

This is achieved on Linux desktop by setting the "transient" hint: `notify-send -t 1 --hint int:transient:1 "this is a test"`