### PR TITLE
Fixed win32 gui class management

### DIFF
--- a/ntfy/backends/win32.py
+++ b/ntfy/backends/win32.py
@@ -49,6 +49,7 @@ def notify(title, message, icon=icon.ico, retcode=None):
                  "Balloon tooltip", title, 200, msg),
             )
             win32gui.DestroyWindow(self.hwnd)
+            win32gui.UnregisterClass(wc.lpszClassName, None)
 
         def OnDestroy(self, hwnd, msg, wparam, lparam):
             win32api.PostQuitMessage(0)  # Terminate the app.


### PR DESCRIPTION
Using as library, it appears this problem:
```python
import ntfy.backends.win32
ntfy.backends.win32.notify("test message", "test")
ntfy.backends.win32.notify("test message", "test2")
```
Second notify return this error:
```
  File "C:\Python27\lib\site-packages\ntfy\backends\win32.py", line 28, in __init__
    classAtom = win32gui.RegisterClass(wc)
pywintypes.error: (1410, 'RegisterClass', 'La classe esiste gi\xe0.')
```
This pull request (tested on Windows 10) fixes the problem