### PR TITLE
Fix typo related to 'hide_command' config

### DIFF
--- a/ntfy/cli.py
+++ b/ntfy/cli.py
@@ -351,7 +351,7 @@ def main(cli_args=None):
         args.longer_than = config['longer_than']
 
     if getattr(args, 'func', None) == run_cmd and 'hide_command' in config:
-        args.hide_command = config['hide_commnad']
+        args.hide_command = config['hide_command']
 
     if hasattr(args, 'func'):
         message, retcode = args.func(args)


### PR DESCRIPTION
I stumbled upon this typo while looking for some args defaults.