### PR TITLE
add optional parameter 'soundfile' for linux backends

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -278,6 +278,7 @@ You will need to install some font that supports emojis (in Debian `fonts-symbol
 Optional parameters:
     * ``urgency`` - Specifies the urgency level (low, normal, critical).
     * ``transient`` - Skip the history (exp: the Gnome message tray) (true, false).
+    * ``soundfile`` - Specifies the notification sound file (e.g. /usr/share/sounds/notif.wav).
 
 Windows Desktop Notifications - ``win32``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/ntfy/backends/linux.py
+++ b/ntfy/backends/linux.py
@@ -8,6 +8,7 @@ def notify(title,
            icon=icon.png,
            urgency=None,
            transient=None,
+           soundfile=None,
            retcode=0):
     try:
         import dbus
@@ -54,6 +55,9 @@ def notify(title,
         logger.warn(
             'Unexpected value for the "transient" option. Expected values (true, false).'
         )
+
+    if soundfile:
+        hints.update({'sound-file': soundfile})
 
     message = message.replace('&', '&amp;')
     dbus_iface.Notify('ntfy', 0, path.abspath(icon), title, message, [], hints,


### PR DESCRIPTION
added ``soundfile`` optional parameter to specifies the notification sound file for linux backends. 

[https://developer.gnome.org/notification-spec/](https://developer.gnome.org/notification-spec/)
`"sound-file" | string | The path to a sound file to play when the notification pops up.`

example usage:
``ntfy -b linux -o soundfile '/home/william/.local/share/sounds/my-notification.wav' send hello``