### PR TITLE
fix missing dot in path

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -92,7 +92,7 @@ Configuring ``ntfy``
 
 ``ntfy`` is configured with a YAML file stored at ``~/.ntfy.yml`` or in standard platform specific locations:
 
-* Linux - ``~/config/ntfy/ntfy.yml``
+* Linux - ``~/.config/ntfy/ntfy.yml``
 * macOS - ``~/Library/Application Support/ntfy/ntfy.yml``
 * Windows - ``C:\Users\<User>\AppData\Local\dschep\ntfy.yml``
 


### PR DESCRIPTION
Linux config lives in `~/.config/` (the dot makes the directory hidden by default), not `~/config/`