### PR TITLE
Add keywords parameters for slack backend

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -228,7 +228,13 @@ Requires extras, install like this: ``pip install ntfy[slack]``.
 
 Required parameter:
     * ``token`` - The Slack service secret token, created in https://api.slack.com/web#authentication
-    * ``recipient`` - The Slack channel or user to send notifications to. If you use the ``#`` symbol the message is send to a Slack channel and if you use the ``@`` symbol the message is send to a Slack user.
+    * ``recipient`` - The Slack channel or user to send notifications to. If you use the ``#`` symbol the message is send to a Slack channel. To send to a Slack user, copy hi `ID` from his profile on Slack.
+
+Optional parameters:
+    * ``username`` - The name that will be used in Slack to send the message
+    * ``icon_url`` or ``icon_emoji`` - The profile picture/ emoji used by Slack to send the message
+    * ``mrkdwn`` - Set markdown parsing by Slack (defaults to True)
+    * other arguments from https://api.slack.com/methods/chat.postMessage
 
 `Instapush <https://instapush.im/>`_ - ``insta``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/ntfy/backends/slack.py
+++ b/ntfy/backends/slack.py
@@ -1,8 +1,9 @@
 from slacker import Slacker
 
 
-def notify(title, message, token, recipient, retcode=None):
+def notify(title, message, token, recipient, retcode=None, **kwargs):
+    kwargs.setdefault("username", title)
 
     slack = Slacker(token)
 
-    slack.chat.post_message(recipient, message)
+    slack.chat.post_message(recipient, message, **kwargs)


### PR DESCRIPTION
I added keywords parameters in the slack backend to enable other parameters from the config, such as the username and the image (Fancier than the `Slack Api Tester` default name).

I mentioned it in the `readme` and also corrected: ~if you use the @ symbol the message is send to a Slack user~ which is no longer supported by Slack Api (only user ids are supported).

Thanks