### PR TITLE
'auto-ntfy-done' would run in background

### DIFF
--- a/ntfy/shell_integration/auto-ntfy-done.sh
+++ b/ntfy/shell_integration/auto-ntfy-done.sh
@@ -21,9 +21,9 @@ function _ntfy_precmd () {
     local appname=$(basename "${ntfy_command%% *}")
     [[ " $AUTO_NTFY_DONE_IGNORE " == *" $appname "* ]] && return
 
-    ntfy $AUTO_NTFY_DONE_OPTS done \
+    (ntfy $AUTO_NTFY_DONE_OPTS done \
         $AUTO_NTFY_DONE_UNFOCUSED_ONLY $AUTO_NTFY_DONE_LONGER_THAN \
-        --formatter "$ntfy_command" "$ret_value" "$duration"
+        --formatter "$ntfy_command" "$ret_value" "$duration" &)
 }
 
 function _ntfy_preexec () {


### PR DESCRIPTION
ntfy contains backends that needs communicate with web, which make it hang up after the command finish.
run ntfy in background would make it faster to return from last command.