### PR TITLE
Fix Matrix backend fails wheen trying to send messages with unicode in them

### DIFF
--- a/ntfy/backends/matrix.py
+++ b/ntfy/backends/matrix.py
@@ -1,4 +1,5 @@
 from matrix_client.client import MatrixClient
+from __future__ import unicode_literals
 
 def notify(title, message, url, roomId, userId=None, token=None, password=None, retcode=None):
 
@@ -11,7 +12,7 @@ def notify(title, message, url, roomId, userId=None, token=None, password=None, 
         client.api.token = token
     else:
         raise Exception("Must supply 'token' or 'password'")
-    msg_plain = u"**{}** {}".format(title, message)
-    msg_html = u"<b>{}</b> {}".format(title, message)
+    msg_plain = "**{}** {}".format(title, message)
+    msg_html = "<b>{}</b> {}".format(title, message)
     room = client.join_room(roomId)
     room.send_html(msg_html, msg_plain)

--- a/ntfy/backends/matrix.py
+++ b/ntfy/backends/matrix.py
@@ -11,7 +11,7 @@ def notify(title, message, url, roomId, userId=None, token=None, password=None, 
         client.api.token = token
     else:
         raise Exception("Must supply 'token' or 'password'")
-    msg_plain = "**{}** {}".format(title, message)
-    msg_html = "<b>{}</b> {}".format(title, message)
+    msg_plain = u"**{}** {}".format(title, message)
+    msg_html = u"<b>{}</b> {}".format(title, message)
     room = client.join_room(roomId)
     room.send_html(msg_html, msg_plain)

--- a/ntfy/backends/matrix.py
+++ b/ntfy/backends/matrix.py
@@ -1,5 +1,5 @@
-from matrix_client.client import MatrixClient
 from __future__ import unicode_literals
+from matrix_client.client import MatrixClient
 
 def notify(title, message, url, roomId, userId=None, token=None, password=None, retcode=None):
 


### PR DESCRIPTION
This makes it not work with things like shell-integration.

I see some other backends also use format() in this way, but I don't use those backends, so im not sure if they are broken or if this is even the proper fix.