### PR TITLE
Fix linux_window_is_focused

### DIFF
--- a/ntfy/terminal.py
+++ b/ntfy/terminal.py
@@ -7,7 +7,7 @@ from sys import platform, stdout
 def linux_window_is_focused():
     xprop_cmd = shlex.split('xprop -root _NET_ACTIVE_WINDOW')
     try:
-        xprop_window_id = int(check_output(xprop_cmd, stdout=PIPE, stderr=PIPE).split()[-1], 16)
+        xprop_window_id = int(check_output(xprop_cmd, stderr=PIPE).split()[-1], 16)
     except CalledProcessError:
         return False
     except ValueError:


### PR DESCRIPTION
As of the [docs](https://docs.python.org/3.6/library/subprocess.html?highlight=subprocess#subprocess.check_output) `stdout` isn't an argument for `check_output` which was making it fail with a `ValueError` and thus behaving like it was never focused.