### PR TITLE
Make theme icons available for linux backend

### DIFF
--- a/ntfy/backends/linux.py
+++ b/ntfy/backends/linux.py
@@ -5,7 +5,7 @@ from ..data import icon
 
 def notify(title,
            message,
-           icon=icon.png,
+           icon=path.abspath(icon.png),
            urgency=None,
            transient=None,
            soundfile=None,
@@ -61,5 +61,5 @@ def notify(title,
         hints.update({'sound-file': soundfile})
 
     message = message.replace('&', '&amp;')
-    dbus_iface.Notify('ntfy', 0, "" if not icon else path.abspath(icon), title, 
+    dbus_iface.Notify('ntfy', 0, "" or icon, title, 
                       message, [], hints, int(timeout))


### PR DESCRIPTION
the abspath is only called on default object icon.png

That way we can specify a theme icon, which does not need an absolute path. For a custom icon, the user needs to specify the absolute path though (maybe that could be added to documentation)

Case example :
```python
from ntfy.backend.linux import notify
notify("warning message", "title", icon="dialog-warning")
```

config file example:
```yaml
backends:
    - linux
linux:
    icon: "dialog-information"
linux-warning:
    backend: linux
    icon: "dialog-warning"
```

This works with Ubuntu, even with application icons, like `firefox`, not sure for other linux versions though