### PR TITLE
Add support for AstroNote

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -393,6 +393,18 @@ Required parameters:
 
 For more info, see _`ntfy-webpush` <https://github.com/dschep/ntfy-webpush>`_
 
+`AstroNote <https://astronote.app>`_ - ``astronote``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Required parameters:
+    * ``token``
+
+Optional parameters:
+    * ``category``
+    * ``display_category``
+    * ``persistent``
+    * ``sound``
+
+For more info see the _AstroNote API Documentation <https://astronote.app/api>_
 
 3rd party backends
 ~~~~~~~~~~~~~~~~~~

--- a/docs/ntfy.backends.rst
+++ b/docs/ntfy.backends.rst
@@ -109,6 +109,13 @@ ntfy.backends.matrix module
     :undoc-members:
     :show-inheritance:
 
+ntfy.backends.astronote module
+-------------------------
+
+.. automodule:: ntfy.backends.astronote
+    :members:
+    :undoc-members:
+    :show-inheritance:
 
 Module contents
 ---------------

--- a/ntfy/backends/astronote.py
+++ b/ntfy/backends/astronote.py
@@ -1,0 +1,53 @@
+from __future__ import print_function
+
+import logging
+
+import requests
+
+from ..config import USER_AGENT
+
+
+def notify(title,
+           message,
+           token=None,
+           category=None,
+           display_category=None,
+           persistent=None,
+           sound=None):
+    """
+    Required parameters:
+        * ``token``
+
+    Optional parameters:
+        * ``category``
+        * ``display_category``
+        * ``persistent``
+        * ``sound``
+    """
+
+    data = {
+        'body': message,
+        'title': title,
+    }
+
+    if category:
+        data['category'] = category
+
+    if display_category is not None:
+        data['display_category'] = display_category
+
+    if persistent is not None:
+        data['persistent'] = persistent
+
+    if sound:
+        data['sound'] = sound
+
+    resp = requests.post(
+        'https://api.astronote.app/1/notify',
+        json=data,
+        headers={
+            'Authorization': 'token %s' % token,
+            'User-Agent': USER_AGENT,
+        })
+
+    resp.raise_for_status()

--- a/tests/test_astronote.py
+++ b/tests/test_astronote.py
@@ -1,0 +1,85 @@
+from unittest import TestCase, main
+
+from mock import patch
+from ntfy.backends.astronote import notify
+from ntfy.config import USER_AGENT
+
+
+class TestAstroNote(TestCase):
+    @patch('requests.post')
+    def test_basic(self, mock_post):
+        notify('title', 'message', token='token')
+        mock_post.assert_called_once_with(
+            'https://api.astronote.app/1/notify',
+            json={
+                'body': 'message',
+                'title': 'title',
+            },
+            headers={
+                'Authorization': 'token token',
+                'User-Agent': USER_AGENT,
+            })
+
+    @patch('requests.post')
+    def test_persistent(self, mock_post):
+        notify('title', 'message', token='token', persistent=False)
+        mock_post.assert_called_once_with(
+            'https://api.astronote.app/1/notify',
+            json={
+                'body': 'message',
+                'title': 'title',
+                'persistent': False,
+            },
+            headers={
+                'Authorization': 'token token',
+                'User-Agent': USER_AGENT,
+            })
+
+    @patch('requests.post')
+    def test_category(self, mock_post):
+        notify('title', 'message', token='token', category='category')
+        mock_post.assert_called_once_with(
+            'https://api.astronote.app/1/notify',
+            json={
+                'body': 'message',
+                'title': 'title',
+                'category': 'category',
+            },
+            headers={
+                'Authorization': 'token token',
+                'User-Agent': USER_AGENT,
+            })
+
+    @patch('requests.post')
+    def test_display_category(self, mock_post):
+        notify('title', 'message', token='token', display_category=True)
+        mock_post.assert_called_once_with(
+            'https://api.astronote.app/1/notify',
+            json={
+                'body': 'message',
+                'title': 'title',
+                'display_category': True,
+            },
+            headers={
+                'Authorization': 'token token',
+                'User-Agent': USER_AGENT,
+            })
+
+    @patch('requests.post')
+    def test_sound(self, mock_post):
+        notify('title', 'message', token='token', sound='silent')
+        mock_post.assert_called_once_with(
+            'https://api.astronote.app/1/notify',
+            json={
+                'body': 'message',
+                'title': 'title',
+                'sound': 'silent',
+            },
+            headers={
+                'Authorization': 'token token',
+                'User-Agent': USER_AGENT,
+            })
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -162,6 +162,18 @@ class TestIntegration(TestCase):
         }
         ntfy_main(['send', 'ms'])
 
+    @patch(builtin_module + '.open', mock_open())
+    @patch('ntfy.config.safe_load')
+    @patch('ntfy.backends.astronote.requests.post')
+    def test_astronote(self, mock_post, mock_yamlload):
+        mock_yamlload.return_value = {
+            'backends': ['astronote'],
+            'astronote': {
+                'token': 'token',
+            },
+        }
+        self.assertEqual(0, ntfy_main(['send', 'foobar']))
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
This patch adds support for [AstroNote](https://astronote.app), which is a small push notifications app for Apple Watch.

I've marked the PR as _Draft_ because I'm still working on one failing test:

```
======================================================================
FAIL: test_astronote (tests.test_integration.TestIntegration)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/stefan/projects/ntfy/.eggs/mock-4.0.2-py3.8.egg/mock/mock.py", line 1369, in patched
    return func(*newargs, **newkeywargs)
  File "/home/stefan/projects/ntfy/tests/test_integration.py", line 175, in test_astronote
    self.assertEqual(0, ntfy_main(['send', 'foobar']))
AssertionError: 0 != 1
```

I'm not entirely sure why this happens yet.
