### PR TITLE
Add debian vim variants

### DIFF
--- a/ntfy/shell_integration/auto-ntfy-done.sh
+++ b/ntfy/shell_integration/auto-ntfy-done.sh
@@ -2,7 +2,7 @@
 # If sourcing this via ntfy auto-done, it is sourced for you.
 
 # Default to ignoring some well known interactive programs
-AUTO_NTFY_DONE_IGNORE=${AUTO_NTFY_DONE_IGNORE:-ntfy emacs htop info less mail man meld most mutt nano screen ssh tail tmux top vi vim watch}
+AUTO_NTFY_DONE_IGNORE=${AUTO_NTFY_DONE_IGNORE:-ntfy emacs htop info less mail man meld most mutt nano screen ssh tail tmux top vi vim vim.athena vim.basic vim.gtk3 vim.nox vim.tiny watch}
 # Bash option example
 #AUTO_NTFY_DONE_OPTS='-b default'
 # Zsh option example


### PR DESCRIPTION
Debian has multiple variants of vim with different configurations. They are symlinked from ``/usr/bin/vim`` via alternatives to the added binaries. ntfy does not detect those and sends notifications for them. This PR fixes that in the default configuration.