### PR TITLE
Swap Slacker for Slack SDK

### DIFF
--- a/ntfy/backends/slack.py
+++ b/ntfy/backends/slack.py
@@ -1,8 +1,8 @@
-from slacker import Slacker
+from slack_sdk import WebClient
 
 
 def notify(title, message, token, recipient, retcode=None):
 
-    slack = Slacker(token)
+    slack = WebClient(token=token)
 
-    slack.chat.post_message(recipient, message)
+    slack.chat_postMessage(channel=recipient, text=message)

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ extra_deps = {
     'instapush': ['instapush'],
     'emoji': ['emoji'],
     'pid':['psutil'],
-    'slack':['slacker'],
+    'slack':['slack_sdk'],
     'rocketchat':['rocketchat-API'],
     'matrix':['matrix_client'],
 }


### PR DESCRIPTION
Slacker (<https://github.com/os/slacker>) has been archived and isn't receiving updates, and ntfy's Slack integration broke for me as a result. This PR swaps out Slacker for the official Slack API (<https://github.com/slackapi/python-slack-sdk>), which is basically 1-to-1. Everything works perfectly on my machine with my limited test cases.