### PR TITLE
Add compatibility with emoji 2.0

### DIFF
--- a/ntfy/cli.py
+++ b/ntfy/cli.py
@@ -358,7 +358,7 @@ def main(cli_args=None):
         if message is None:
             return 0
         if emojize is not None and not args.no_emoji:
-            message = emojize(message, use_aliases=True)
+            message = emojize(message, language='alias')
         return notify(
             message,
             args.title,

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ extra_deps = {
         'sleekxmpp', 'dnspython' if version_info[0] < 3 else 'dnspython3'],
     'telegram': ['telegram-send'],
     'instapush': ['instapush'],
-    'emoji': ['emoji'],
+    'emoji': ['emoji >= 1.6.2'],
     'pid':['psutil'],
     'slack':['slack_sdk'],
     'rocketchat':['rocketchat-API'],


### PR DESCRIPTION
Emoji deprecated the use_alias parameter in 1.6.2. This changes our use
to the new API which exists since that version. Without this change,
ntfy cannot be used with emoji 2.0 or higher.