### PR TITLE
Fix keyword argument in emojize

### DIFF
--- a/ntfy/cli.py
+++ b/ntfy/cli.py
@@ -358,7 +358,7 @@ def main(cli_args=None):
         if message is None:
             return 0
         if emojize is not None and not args.no_emoji:
-            message = emojize(message, use_aliases=True)
+            message = emojize(message, language='alias')
         return notify(
             message,
             args.title,


### PR DESCRIPTION
Fix a keyword argument in emojize. The following error was raised:
```
message = emojize(message, use_aliases=True)
TypeError: emojize() got an unexpected keyword argument 'use_aliases'
```