### PR TITLE
Log ImportError exception.

### DIFF
--- a/ntfy/__init__.py~
+++ b/ntfy/__init__.py~
@@ -43,7 +43,7 @@ def notify(message, title, config=None, **kwargs):
             notifier = import_module(backend_notifier_path)
         except ImportError as e:
             logging.getLogger(__name__).error(
-                    "Could not import notifier from '{}'. Reason: {}"
+                    'Could not import notifier from {}. Reason: {}'
                     .format(backend_notifier_path, e))
             try:
                 notifier = import_module(backend)


### PR DESCRIPTION
I was only able to figure out the cause for the exception detailed in https://github.com/dschep/ntfy/issues/260 after adding the logging statements found in the PR. It would make sense to add these logging statements into the official repository so that others can quickly diagnose backend notifier `ImportError` exceptions in the future.