### PR TITLE
Avoid tainting the default config

### DIFF
--- a/ntfy/config.py
+++ b/ntfy/config.py
@@ -9,7 +9,7 @@ from appdirs import site_config_dir, user_config_dir
 from ruamel import yaml
 
 from . import __version__
-from .default_config import config as default_configuration
+from .default_config import get_default_config
 
 if yaml.version_info < (0, 15):
     safe_load = yaml.safe_load
@@ -34,7 +34,7 @@ def load_config(config_path=DEFAULT_CONFIG):
     except IOError as e:
         if e.errno == errno.ENOENT and config_path == DEFAULT_CONFIG:
             logger.info('{} not found'.format(config_path))
-            config = default_configuration
+            config = get_default_config()
         else:
             logger.error(
                 'Failed to open {}'.format(config_path), exc_info=True)

--- a/ntfy/default_config.py
+++ b/ntfy/default_config.py
@@ -1,1 +1,2 @@
-config = {}
+def get_default_config():
+    return {}


### PR DESCRIPTION
When running tests, depending on the order they are discovered, the default_config can become tainted before the test_default_config test is run. This causes this test to fail.

Admittedly its likely never an issue when using ntfy as a script. But its in general a good practice not to direcly use mutable objects as default values and less flaky tests are easier to handle.