### PR TITLE
Fix compatibility with Python 3.11, 3.12, and 3.13

### DIFF
--- a/ntfy/__init__.py
+++ b/ntfy/__init__.py
@@ -65,7 +65,7 @@ def notify(message, title, config=None, **kwargs):
                 notifier = e.module
                 e = e.exception
 
-            args, _, _, defaults = getfullargspec(notifier.notify)
+            args, _, _, defaults, *_ = getfullargspec(notifier.notify)
             possible_args = set(args)
             required_args =  set(args) if defaults is None else set(args[:-len(defaults)])
             required_args -= set(['title', 'message', 'retcode'])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -174,7 +174,7 @@ class TestMain(TestCase):
     @patch('ntfy.backends.default.notify')
     def test_args(self, mock_notify):
         mock_notify.return_value = None
-        self.assertEquals(0,
+        self.assertEqual(0,
                           ntfy_main([
                               '-o', 'foo', 'bar', '-b', 'default', '-t',
                               'TITLE', 'send', 'test'


### PR DESCRIPTION
This improves on the Python-3.11-compatibility fix that can already be found on master but sadly seems to have missed a small detail. In addition, it replaces usage of the last remaining deprecated `assertEquals` in the tests by `assertEqual`, resolving an issue with Python 3.12 which dropped this.