### PR TITLE
fix telegram coroutine not awaited

### DIFF
--- a/ntfy/backends/telegram.py
+++ b/ntfy/backends/telegram.py
@@ -1,12 +1,10 @@
 from os import makedirs, path
-
 from appdirs import user_config_dir
-
 from telegram_send import configure, send
+import asyncio
 
 config_dir = user_config_dir('ntfy', 'dschep')
 config_file = path.join(config_dir, 'telegram.ini')
-
 
 def notify(title, message, retcode=None):
     """Sends message over Telegram using telegram-send, title is ignored."""
@@ -14,5 +12,5 @@ def notify(title, message, retcode=None):
         if not path.exists(config_dir):
             makedirs(config_dir)
         print("Follow the instructions to configure the Telegram backend.\n")
-        configure(config_file)
-    send(messages=[message], conf=config_file)
+        asyncio.run(configure(config_file))
+    asyncio.run(send(messages=[message], conf=config_file))


### PR DESCRIPTION
Telegram was broken giving me this error: 
RuntimeWarning: coroutine 'configure' was never awaited
telegram-send version is 0.37, installed automatically when calling pip install ntfy[telegram]
Turns out now it needs to be wrapped inside an an asyncio.run
